### PR TITLE
Potential fix for code scanning alert no. 1579: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/neuralegion.yml
+++ b/.github/workflows/neuralegion.yml
@@ -149,6 +149,9 @@
 
 name: "NeuraLegion"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/1579](https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/1579)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's purpose (running scans and auditing outbound calls), it likely only needs `contents: read` permissions. This change will ensure the workflow adheres to the principle of least privilege and avoids unnecessary write access.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
