### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - maintenance/**
+permissions:
+  contents: read
 
 defaults:
   run:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/22](https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/22)

To resolve this issue, add an explicit `permissions` block to the root of the workflow file. This block will apply minimal necessary permissions to all jobs in the workflow that do not have individual `permissions` blocks defined. Based on the workflow's description and steps, the most likely minimal permissions needed are `contents: read`, since the workflow appears to fetch code from the repository and does not explicitly modify it.

The new `permissions` block will be added immediately after the `on:` block (line 12). No changes will be made to individual jobs unless they require specific permissions not covered by the global block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
