### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: "Pull Request Labeler"
 on:
   pull_request_target:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/9](https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/9)

The best way to fix the problem is to add a `permissions` block at the root level of the workflow. This ensures that all jobs in the workflow inherit restricted permissions unless overridden locally. Given the workflow's purpose (`pr-labeler`), the `GITHUB_TOKEN` likely only needs `contents: read` and `pull-requests: write` permissions. These permissions allow the workflow to read repository contents and modify pull requests (e.g., adding labels).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
