### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,6 +38,8 @@ jobs:
 
   build_wheels:
     name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform }}
+    permissions:
+      contents: read
     needs: get_commit_message
     if: >-
       contains(needs.get_commit_message.outputs.message, '[wheel build]') ||


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/12](https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/12)

**General Fix:**  
Add a `permissions` key with the minimal required permissions for the `build_wheels` job. Since the job only checks out code and uploads artifacts, it does not require write access to repository contents or other scopes; `contents: read` is sufficient.

**Detailed Fix:**  
Insert a `permissions:` block with `contents: read` under the `build_wheels` job definition (i.e., at the same indentation level as `needs`, `if`, `runs-on`, etc.), specifically after the job name line (line 40).

**Implementation Requirements:**  
- No imports or external libraries are needed.
- Only a single line addition to the YAML file is required.
- No changes to job logic or steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
