### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: Build Base Docker Image
 
+permissions:
+  contents: read
+
 on:
   push: 
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/5](https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/5)

To fix the problem, you should add an explicit `permissions` block to the workflow. This can be added either at the root level (before `jobs:`) to apply to all jobs, or inside the specific job (`build:`) if you want job-level granularity. The minimal recommended starting point is `contents: read`, which allows jobs to read repository contents but not to write to them. Review if any steps need additional permissions (e.g., if you use the workflow to write issues, you might need `issues: write`, but for this workflow, `contents: read` is sufficient).

The fix involves editing `.github/workflows/docker.yml` to add the following lines near the top of the file, after the `name` block and before `jobs:`:

```yaml
permissions:
  contents: read
```

No additional imports or dependencies are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
