### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build Gitpod Docker image
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/4](https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/4)

To fix the problem, we should add an explicit `permissions` block to the workflow (at the root level, before `jobs:`). This will restrict the permissions granted to the GITHUB_TOKEN to the minimum required. For this workflow, the minimal starting point is `contents: read`, as the job only interacts with the codebase for cloning and does not require any write actions (e.g., pushing commits, creating issues, or pull requests).

**Steps:**
- Edit `.github/workflows/gitpod.yml`.
- Insert the following block after the workflow `name:` and before the `on:` key:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
