### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Test on Cygwin
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/2](https://github.com/Git-Hub-Chris/NumPy/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block to the root of the workflow. Assign only the minimum permissions required for the workflow tasks, which in this case appear to be limited to reading repository contents. This ensures that the GITHUB_TOKEN has restricted access, mitigating security risks. The `permissions` key should be added at the top level of the workflow, directly under the `name` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
